### PR TITLE
Implement inequalities (>= and <=) in braid

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -93,7 +93,7 @@ export interface UnaryNode extends ExpressionNode {
 
 export interface BinaryNode extends ExpressionNode {
   tag: "binary";
-  op: "+" | "-" | "*" | "/" | "==" | "!=";
+  op: "+" | "-" | "*" | "/" | "==" | "!=" | ">=" | "<=";
   lhs: ExpressionNode;
   rhs: ExpressionNode;
 }

--- a/src/backends/gl.ts
+++ b/src/backends/gl.ts
@@ -138,6 +138,10 @@ const _GL_ARITH_BINARY_TYPE = new OverloadedType([
   new FunType([FLOAT4X4, FLOAT], FLOAT4X4),
   new FunType([FLOAT, FLOAT4X4], FLOAT4X4),
 ]);
+const _GL_COMPARE_TYPE = new OverloadedType([
+  new FunType([INT, INT], BOOLEAN),
+  new FunType([FLOAT, FLOAT], BOOLEAN),
+]);
 const _GL_ARITH_UNARY_BINARY_TYPE = new OverloadedType(
   _GL_ARITH_UNARY_TYPE.types.concat(_GL_ARITH_BINARY_TYPE.types)
 );
@@ -230,14 +234,10 @@ export const INTRINSICS: TypeMap = {
 
   // Boolean binary operators inherited from core.
   '~': new FunType([BOOLEAN], BOOLEAN),
-  '==': new OverloadedType([
-    new FunType([INT, INT], BOOLEAN),
-    new FunType([FLOAT, FLOAT], BOOLEAN),
-  ]),
-  '!=': new OverloadedType([
-    new FunType([INT, INT], BOOLEAN),
-    new FunType([FLOAT, FLOAT], BOOLEAN),
-  ]),
+  '==': _GL_COMPARE_TYPE,
+  '!=': _GL_COMPARE_TYPE,
+  '>=': _GL_COMPARE_TYPE,
+  '<=': _GL_COMPARE_TYPE,
 
   // Texture sampling.
   texture2D: new FunType([TEXTURE, FLOAT2], FLOAT4),

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -306,7 +306,7 @@ addbinop
 mulbinop
   = [*/]
 comparebinop
-  = "==" / "!="
+  = "==" / "!=" / ">=" / "<="
 
 unop "unary operator"
   = [+\-\~]

--- a/src/type_check.ts
+++ b/src/type_check.ts
@@ -112,6 +112,8 @@ export const BUILTIN_OPERATORS: TypeMap = {
   '~': new FunType([BOOLEAN], BOOLEAN),
   '==': _COMPARE_TYPE,
   '!=': _COMPARE_TYPE,
+  '>=': _COMPARE_TYPE,
+  '<=': _COMPARE_TYPE,
 };
 
 


### PR DESCRIPTION
It works well in webgl mode but it throws some type errors in the normal mode. And the error message is different if you type characters in different order. 