### PR TITLE
Use TypeScript tagged unions for AST nodes and types

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -19,7 +19,7 @@ export interface Location {
 /**
  * The base type for all nodes in the AST.
  */
-export interface SyntaxNode {
+interface BaseSyntaxNode {
   /**
    * A string indicating the type of AST node. Every `interface` in this type
    * hierarchy corresponds to a unique string.
@@ -44,179 +44,169 @@ export interface SyntaxNode {
 /**
  * A root AST node that acts as a parent for joining several source ASTs together
  */
- export interface RootNode extends SyntaxNode {
+ export interface RootNode extends BaseSyntaxNode {
    tag: "root";
    children: ExpressionNode[];
  }
 
-/**
- * An AST node that's an expression. This is almost everything---just not
- * parameters and types.
- */
-export interface ExpressionNode extends SyntaxNode {
-}
-
-export interface LiteralNode extends ExpressionNode {
+export interface LiteralNode extends BaseSyntaxNode {
   tag: "literal";
   value: number | string | boolean;
   type: "int" | "float" | "string" | "boolean";
 }
 
-export interface SeqNode extends ExpressionNode {
+export interface SeqNode extends BaseSyntaxNode {
   tag: "seq";
   lhs: ExpressionNode;
   rhs: ExpressionNode;
 }
 
-export interface LetNode extends ExpressionNode {
+export interface LetNode extends BaseSyntaxNode {
   tag: "let";
   ident: string;
   expr: ExpressionNode;
 }
 
-export interface AssignNode extends ExpressionNode {
+export interface AssignNode extends BaseSyntaxNode {
   tag: "assign";
   ident: string;
   expr: ExpressionNode;
 }
 
-export interface LookupNode extends ExpressionNode {
+export interface LookupNode extends BaseSyntaxNode {
   tag: "lookup";
   ident: string;
 }
 
-export interface UnaryNode extends ExpressionNode {
+export interface UnaryNode extends BaseSyntaxNode {
   tag: "unary";
   op: "+" | "-" | "~";
   expr: ExpressionNode;
 }
 
-export interface BinaryNode extends ExpressionNode {
+export interface BinaryNode extends BaseSyntaxNode {
   tag: "binary";
   op: "+" | "-" | "*" | "/" | "==" | "!=" | ">=" | "<=";
   lhs: ExpressionNode;
   rhs: ExpressionNode;
 }
 
-export interface QuoteNode extends ExpressionNode {
+export interface QuoteNode extends BaseSyntaxNode {
   tag: "quote";
   expr: ExpressionNode;
   annotation: string;
   snippet: boolean;
 }
 
-export interface EscapeNode extends ExpressionNode {
+export interface EscapeNode extends BaseSyntaxNode {
   tag: "escape";
   expr: ExpressionNode;
   kind: "splice" | "persist" | "snippet";
   count: number;
 }
 
-export interface RunNode extends ExpressionNode {
+export interface RunNode extends BaseSyntaxNode {
   tag: "run";
   expr: ExpressionNode;
 }
 
-export interface FunNode extends ExpressionNode {
+export interface FunNode extends BaseSyntaxNode {
   tag: "fun";
   params: ParamNode[];
   body: ExpressionNode;
 }
 
-export interface ParamNode extends SyntaxNode {
+export interface ParamNode extends BaseSyntaxNode {
   tag: "param";
   name: string;
   type: TypeNode;
 }
 
-export interface CallNode extends ExpressionNode {
+export interface CallNode extends BaseSyntaxNode {
   tag: "call";
   fun: ExpressionNode;
   args: ExpressionNode[];
 }
 
-export interface ExternNode extends ExpressionNode {
+export interface ExternNode extends BaseSyntaxNode {
   tag: "extern";
   name: string;
   type: TypeNode;
   expansion: string;  // Or null, if it should expand to the name itself.
 }
 
-export interface IfNode extends ExpressionNode {
+export interface IfNode extends BaseSyntaxNode {
   tag: "if";
   cond: ExpressionNode;
   truex: ExpressionNode;
   falsex: ExpressionNode;
 }
 
-export interface WhileNode extends ExpressionNode {
+export interface WhileNode extends BaseSyntaxNode {
   tag: "while";
   cond: ExpressionNode;
   body: ExpressionNode;
 }
 
-export interface MacroCallNode extends ExpressionNode {
+export interface MacroCallNode extends BaseSyntaxNode {
   tag: "macrocall";
   macro: string;
   args: ExpressionNode[];
 }
 
-export interface TypeAliasNode extends ExpressionNode {
+export interface TypeAliasNode extends BaseSyntaxNode {
   tag: "type_alias";
   ident: string;
   type: TypeNode;
 }
 
-export interface TupleNode extends ExpressionNode {
+export interface TupleNode extends BaseSyntaxNode {
   tag: "tuple";
   exprs: ExpressionNode[];
 }
 
-export interface TupleIndexNode extends ExpressionNode {
+export interface TupleIndexNode extends BaseSyntaxNode {
   tag: "tupleind";
   tuple: ExpressionNode;
   index: number;
 }
 
-export interface AllocNode extends ExpressionNode {
+export interface AllocNode extends BaseSyntaxNode {
   tag: "alloc";
   ident: string;
   expr: ExpressionNode;
 }
 
-export interface TypeNode extends SyntaxNode {
-}
-
-export interface OverloadedTypeNode extends TypeNode {
+export interface OverloadedTypeNode extends BaseSyntaxNode {
   tag: "type_overloaded";
   types: TypeNode[];
 }
 
-export interface PrimitiveTypeNode extends TypeNode {
+export interface PrimitiveTypeNode extends BaseSyntaxNode {
   tag: "type_primitive";
   name: string;
 }
 
-export interface InstanceTypeNode extends TypeNode {
+export interface InstanceTypeNode extends BaseSyntaxNode {
   tag: "type_instance";
   name: string;
   arg: TypeNode;
 }
 
-export interface FunTypeNode extends TypeNode {
+export interface FunTypeNode extends BaseSyntaxNode {
   tag: "type_fun";
   params: TypeNode[];
   ret: TypeNode;
 }
 
-export interface CodeTypeNode extends TypeNode {
+export interface CodeTypeNode extends BaseSyntaxNode {
   tag: "type_code";
   inner: TypeNode;
   annotation: string;
   snippet: boolean;
 }
 
-export interface TupleTypeNode extends TypeNode {
+export interface TupleTypeNode extends BaseSyntaxNode {
   tag: "type_tuple";
   components: TypeNode[];
 }
@@ -230,7 +220,21 @@ export interface TupleTypeNode extends TypeNode {
  * index into the value list (called a `Pers` in the interpreter) associated
  * with the `Code` that it appears inside.
  */
-export interface PersistNode extends ExpressionNode {
+export interface PersistNode extends BaseSyntaxNode {
   tag: "persist";
   index: number;
 }
+
+/**
+ * An AST node that's an expression. This is almost everything---just not
+ * parameters and types.
+ */
+export type ExpressionNode = LiteralNode | SeqNode | LetNode | AssignNode |
+  LookupNode | UnaryNode | BinaryNode | QuoteNode | EscapeNode | RunNode |
+  FunNode | CallNode | ExternNode | IfNode | WhileNode | MacroCallNode |
+  TypeAliasNode | TupleNode | TupleIndexNode | AllocNode | PersistNode;
+
+export type TypeNode = OverloadedTypeNode | PrimitiveTypeNode |
+  InstanceTypeNode | FunTypeNode | CodeTypeNode | TupleTypeNode;
+
+export type SyntaxNode = RootNode | ExpressionNode | ParamNode | TypeNode;

--- a/src/backends/emitutil.ts
+++ b/src/backends/emitutil.ts
@@ -1,6 +1,6 @@
 import { Emitter, emit } from './emitter';
 import * as ast from '../ast';
-import { Type, FunType, OverloadedType } from '../type';
+import { Type, FunType, OverloadedType, TypeType } from '../type';
 import { complete_visit, ast_visit } from '../visit';
 import { Prog, Variant } from '../compile/ir';
 
@@ -202,7 +202,7 @@ function flatten_seq(tree: ast.SyntaxNode): ast.ExpressionNode[] {
       }
     }
   );
-  return ast_visit(rules, tree, null);
+  return <ast.ExpressionNode[]> ast_visit(rules, tree, null);
 }
 
 /**
@@ -281,11 +281,13 @@ export function emit_body(emitter: Emitter, tree: ast.SyntaxNode,
  * type.
  */
 export function is_fun_type(type: Type): boolean {
-  if (type instanceof FunType) {
-    return true;
-  } else if (type instanceof OverloadedType) {
-    return is_fun_type(type.types[0]);
-  } else {
-    return false;
+  switch (type.type) {
+    case TypeType.FUN:
+    case TypeType.VARIADIC_FUN:
+      return true;
+    case TypeType.OVERLOADED:
+      return is_fun_type(type.types[0]);
+    default:
+      return false;
   }
 }

--- a/src/backends/gl.ts
+++ b/src/backends/gl.ts
@@ -1,4 +1,4 @@
-import { Type, TypeMap } from '../type';
+import { Type, TypeMap, TypeType } from '../type';
 import {
   PrimitiveType,
   FunType,
@@ -292,8 +292,7 @@ export const INTRINSICS: TypeMap = {
 
 function is_intrinsic(tree: ast.CallNode, name: string) {
   if (tree.fun.tag === "lookup") {
-    let fun = <ast.LookupNode> tree.fun;
-    return fun.ident === name;
+    return tree.fun.ident === name;
   }
   return false;
 }
@@ -388,15 +387,12 @@ export function shadervarsym(scopeid: number, varid: number) {
 // Check whether the type of a value implies that it needs to be passed as an
 // attribute: i.e., it is an array type.
 export function _attribute_type(t: Type) {
-  if (t instanceof InstanceType) {
-    return t.cons === BUFFER;
-  }
-  return false;
+  return t.type === TypeType.INSTANCE && t.cons === BUFFER;
 }
 
 // A helper function that unwraps array types. Non-array types are unaffected.
 export function _unwrap_array(t: Type): Type {
-  if (t instanceof InstanceType) {
+  if (t.type === TypeType.INSTANCE) {
     if (t.cons === BUFFER) {
       // Get the inner type: the array element type.
       return t.arg;

--- a/src/backends/glsl.ts
+++ b/src/backends/glsl.ts
@@ -1,4 +1,4 @@
-import { Type, PrimitiveType, INT, FLOAT } from '../type';
+import { Type, PrimitiveType, INT, FLOAT, TypeType } from '../type';
 import { TypeCheck, TypeEnv } from '../type_check';
 import * as ast from '../ast';
 import { stack_lookup } from '../util';
@@ -63,7 +63,7 @@ function emit_decl(qualifier: string, type: string, name: string) {
 }
 
 function emit_type(type: Type): string {
-  if (type instanceof PrimitiveType) {
+  if (type.type === TypeType.PRIMITIVE) {
     let name = TYPE_NAMES[type.name];
     if (name === undefined) {
       throw "error: primitive type " + type.name + " unsupported in GLSL";

--- a/src/backends/js.ts
+++ b/src/backends/js.ts
@@ -1,4 +1,4 @@
-import { Type, OverloadedType, FunType, CodeType } from '../type';
+import { Type, OverloadedType, FunType, CodeType, TypeType } from '../type';
 import { varsym, indent, emit_seq, emit_exprs, emit_assign, emit_lookup, emit_if,
   emit_body, paren, splicesym, persistsym, procsym, progsym,
   emit_while, variantsym, is_fun_type, check_header } from './emitutil';
@@ -250,7 +250,7 @@ export let compile_rules = {
     let progex = emit(emitter, tree.expr);
 
     let [t, _] = emitter.ir.type_table[tree.expr.id!];
-    if (t instanceof CodeType) {
+    if (t.type === TypeType.CODE) {
       // Invoke the appropriate runtime function for executing code values.
       // We use a simple call wrapper for "progfuncs" and a more complex
       // `eval` trick for ordinary string code.

--- a/src/backends/webgl.ts
+++ b/src/backends/webgl.ts
@@ -6,7 +6,7 @@ import {
   FLOAT4X4, FLOAT3X3, FLOAT4, SHADER_ANNOTATION, TEXTURE, FLOAT3, FLOAT2, CUBE_TEXTURE
 } from './gl';
 import { progsym, paren, variant_suffix } from './emitutil';
-import { Type, PrimitiveType, FLOAT, INT } from '../type';
+import { Type, PrimitiveType, FLOAT, INT, TypeType } from '../type';
 import { Emitter, emit, emit_main } from './emitter';
 import { ASTVisit, ast_visit, compose_visit } from '../visit';
 import * as ast from '../ast';
@@ -174,7 +174,7 @@ function emit_param_binding(scopeid: number, type: Type, varid: number,
       out += `gl.uniform1i(${locname}, ${texture_index})`;
       return out;
 
-    } else if (type instanceof PrimitiveType) {
+    } else if (type.type === TypeType.PRIMITIVE) {
       // Ordinary uniform.
       let fname = GL_UNIFORM_FUNCTIONS[type.name];
       if (fname === undefined) {
@@ -198,7 +198,7 @@ function emit_param_binding(scopeid: number, type: Type, varid: number,
 
   } else {
     // Array types are bound as attributes.
-    if (type instanceof PrimitiveType) {
+    if (type.type === TypeType.PRIMITIVE) {
       // The value is a WebGL buffer object.
       let buf_expr = paren(value);
 

--- a/src/compile/lift.ts
+++ b/src/compile/lift.ts
@@ -3,7 +3,7 @@ import { Gen, fix, set_add } from '../util';
 import { ASTFold, ast_fold_rules, compose_visit, ast_visit } from '../visit';
 import { TypeTable } from '../type_elaborate';
 import { Scope, Prog, Proc, Escape, DefUseTable } from './ir';
-import { CodeType } from '../type';
+import { CodeType, TypeType } from '../type';
 
 // A simple, imperative walk that indexes *all* the syntax nodes in a tree by
 // their ID. We use this to build Procs and Progs by looking up the
@@ -54,7 +54,7 @@ function gen_assoc_snippets(type_table: TypeTable): Gen<AssocSnippets> {
         if (tree.snippet) {
           ei = ei.slice(0);
           let [t] = type_table[tree.id!];
-          if (t instanceof CodeType) {
+          if (t.type === TypeType.CODE) {
             if (t.snippet === null) {
               throw "error: snippet quote without snippet ID";
             }
@@ -163,7 +163,7 @@ function skeleton_scopes(tree: ast.SyntaxNode, containers: number[],
   // And an empty "main" proc for the top-level scope.
   let main: Proc = {
     id: null,
-    body: tree,
+    body: <ast.ExpressionNode> tree,
     params: [],
 
     free: [],

--- a/src/compile/presplice.ts
+++ b/src/compile/presplice.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from '../ast';
+import { SyntaxNode, ExpressionNode } from '../ast';
 import { hd, tl, cons, set_add, set_diff, set_union } from '../util';
 import { Prog, Proc, Scope, Variant, is_prog } from './ir';
 import { ast_translate_rules, ast_visit } from '../visit';
@@ -105,7 +105,7 @@ function scope_variant<T extends Scope>(orig: T, config: number[],
   }
 
   // Generate the program body using these substitutions.
-  var_scope.body = substitute(orig.body, substitutions);
+  var_scope.body = <ExpressionNode> substitute(orig.body, substitutions);
 
   return var_scope;
 }

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -116,7 +116,7 @@ export function frontend(config: Config, sources: string[],
     }
     config.log(tree);
 
-    root.children.push(tree);
+    root.children.push(<ExpressionNode> tree);
   }
 
   // Check and elaborate types.

--- a/src/interp.ts
+++ b/src/interp.ts
@@ -141,7 +141,7 @@ let Interp: ASTVisit<State, [Value, State]> = {
     let [t, s, p] = quote_interp(tree.expr, level, state, []);
 
     // Wrap the resulting AST as a code value.
-    return [new Code(t, p, tree.annotation), s];
+    return [new Code(<ast.ExpressionNode> t, p, tree.annotation), s];
   },
 
   visit_escape(tree: ast.EscapeNode, state: State): [Value, State] {

--- a/src/sugar.ts
+++ b/src/sugar.ts
@@ -4,7 +4,7 @@ import * as ast from './ast';
 import { ASTTranslate, gen_translate, ast_translate_rules,
   ast_visit, compose_visit } from './visit';
 import { Gen, stack_lookup, fix, compose, zip } from './util';
-import { FunType, CodeType } from './type';
+import { FunType, CodeType, TypeType } from './type';
 
 // Another type test for the specific kind of node we're interested in. We'll
 // use this to follow one piece of advice from the "Scrap Your Boilerplate"
@@ -91,7 +91,7 @@ function _desugar_macros(type_table: TypeTable,
         let macro_args: ast.ExpressionNode[] = [];
         let has_snippets = false;
         for (let [param, arg] of zip(fun_type.params, tree.args)) {
-          if (param instanceof CodeType) {
+          if (param.type === TypeType.CODE) {
             // Code parameter. Wrap the argument in a quote.
             let as_snippet = !!param.snippet_var;
             has_snippets = has_snippets || as_snippet;

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -34,51 +34,51 @@ export function ast_visit<P, R>(visitor: ASTVisit<P, R>,
                                 tree: ast.SyntaxNode, param: P): R {
   switch (tree.tag) {
     case "root":
-      return visitor.visit_root(<ast.RootNode> tree, param);
+      return visitor.visit_root(tree, param);
     case "literal":
-      return visitor.visit_literal(<ast.LiteralNode> tree, param);
+      return visitor.visit_literal(tree, param);
     case "seq":
-      return visitor.visit_seq(<ast.SeqNode> tree, param);
+      return visitor.visit_seq(tree, param);
     case "let":
-      return visitor.visit_let(<ast.LetNode> tree, param);
+      return visitor.visit_let(tree, param);
     case "assign":
-      return visitor.visit_assign(<ast.AssignNode> tree, param);
+      return visitor.visit_assign(tree, param);
     case "lookup":
-      return visitor.visit_lookup(<ast.LookupNode> tree, param);
+      return visitor.visit_lookup(tree, param);
     case "unary":
-      return visitor.visit_unary(<ast.UnaryNode> tree, param);
+      return visitor.visit_unary(tree, param);
     case "binary":
-      return visitor.visit_binary(<ast.BinaryNode> tree, param);
+      return visitor.visit_binary(tree, param);
     case "type_alias":
-      return visitor.visit_typealias(<ast.TypeAliasNode> tree, param);
+      return visitor.visit_typealias(tree, param);
     case "quote":
-      return visitor.visit_quote(<ast.QuoteNode> tree, param);
+      return visitor.visit_quote(tree, param);
     case "escape":
-      return visitor.visit_escape(<ast.EscapeNode> tree, param);
+      return visitor.visit_escape(tree, param);
     case "run":
-      return visitor.visit_run(<ast.RunNode> tree, param);
+      return visitor.visit_run(tree, param);
     case "fun":
-      return visitor.visit_fun(<ast.FunNode> tree, param);
+      return visitor.visit_fun(tree, param);
     case "call":
-      return visitor.visit_call(<ast.CallNode> tree, param);
+      return visitor.visit_call(tree, param);
     case "extern":
-      return visitor.visit_extern(<ast.ExternNode> tree, param);
+      return visitor.visit_extern(tree, param);
     case "persist":
-      return visitor.visit_persist(<ast.PersistNode> tree, param);
+      return visitor.visit_persist(tree, param);
     case "if":
-      return visitor.visit_if(<ast.IfNode> tree, param);
+      return visitor.visit_if(tree, param);
     case "while":
-      return visitor.visit_while(<ast.WhileNode> tree, param);
+      return visitor.visit_while(tree, param);
     case "macrocall":
-      return visitor.visit_macrocall(<ast.MacroCallNode> tree, param);
+      return visitor.visit_macrocall(tree, param);
     case "param":
-      return visitor.visit_param!(<ast.ParamNode> tree, param);
+      return visitor.visit_param!(tree, param);
     case "tuple":
-      return visitor.visit_tuple(<ast.TupleNode> tree, param);
+      return visitor.visit_tuple(tree, param);
     case "tupleind":
-      return visitor.visit_tupleind(<ast.TupleIndexNode> tree, param);
+      return visitor.visit_tupleind(tree, param);
     case "alloc":
-      return visitor.visit_alloc(<ast.AllocNode> tree, param);
+      return visitor.visit_alloc(tree, param);
 
     default:
       throw "error: unknown syntax node " + tree.tag;
@@ -290,20 +290,22 @@ export function type_ast_visit<P, R>(visitor: TypeASTVisit<P, R>,
                                      tree: ast.TypeNode, param: P): R {
   switch (tree.tag) {
     case "type_primitive":
-      return visitor.visit_primitive(<ast.PrimitiveTypeNode> tree, param);
+      return visitor.visit_primitive(tree, param);
     case "type_fun":
-      return visitor.visit_fun(<ast.FunTypeNode> tree, param);
+      return visitor.visit_fun(tree, param);
     case "type_code":
-      return visitor.visit_code(<ast.CodeTypeNode> tree, param);
+      return visitor.visit_code(tree, param);
     case "type_instance":
-      return visitor.visit_instance(<ast.InstanceTypeNode> tree, param);
+      return visitor.visit_instance(tree, param);
     case "type_overloaded":
-      return visitor.visit_overloaded(<ast.OverloadedTypeNode> tree, param);
+      return visitor.visit_overloaded(tree, param);
     case "type_tuple":
-      return visitor.visit_tuple(<ast.TupleTypeNode> tree, param);
+      return visitor.visit_tuple(tree, param);
 
     default:
-      throw "error: unknown type syntax node " + tree.tag;
+      // Note: Typecast to 'any' because TypeScript does not believe this
+      // case is possible.
+      throw "error: unknown type syntax node " + (<any> tree).tag;
   }
 }
 


### PR DESCRIPTION
Fixes #18.

Some notes:

* Introduces a few new casts in locations where ExpressionNode is expected, but an API returns SyntaxNode.
* VariadicFunType no longer extends FunType due to how tagged unions work; instead, it extends BaseFunType
* `instanceof` checks for types all changed to check `.type` field. In a few cases, this is more verbose.
  * And, maybe, clearer?
* `Type` is no longer a class, so I had to modify `instanceof Type` checks in a few locations that had to differentiate between an object and a string.
  * If those locations can contain `null`, then I should change them from checking if the value is an object to checking if the value is not a string (since `typeof(null) === 'object'`).
* You may rightfully object to the name `TypeType` :)
* `make test` appears to succeed, but that's the extent of the testing I've done.