### PR TITLE
Add generic function and multi-tuple

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -131,6 +131,7 @@ export interface CallNode extends BaseSyntaxNode {
   tag: "call";
   fun: ExpressionNode;
   args: ExpressionNode[];
+  type?: TypeNode;
 }
 
 export interface ExternNode extends BaseSyntaxNode {

--- a/src/backends/gl.ts
+++ b/src/backends/gl.ts
@@ -298,6 +298,14 @@ export const INTRINSICS: TypeMap = {
       VOID
     )
   ),
+  length: new QuantifiedType(TVAR,
+    new FunType(
+      [
+        new InstanceType(ARRAY, new VariableType(TVAR))
+      ],
+      INT
+    )
+  ),
 
   // Vector "swizzling" in GLSL code for destructuring vectors. This is the
   // equivalent of the dot syntax `vec.x` or `vec.xxz` in plain GLSL. This is

--- a/src/backends/gl.ts
+++ b/src/backends/gl.ts
@@ -306,6 +306,9 @@ export const INTRINSICS: TypeMap = {
       INT
     )
   ),
+  equal: new OverloadedType([
+    new FunType([STRING, STRING], BOOLEAN)
+  ]),
 
   // Vector "swizzling" in GLSL code for destructuring vectors. This is the
   // equivalent of the dot syntax `vec.x` or `vec.xxz` in plain GLSL. This is

--- a/src/backends/webglfunc.ts
+++ b/src/backends/webglfunc.ts
@@ -488,8 +488,7 @@ let funcMap: FuncMap = {
       funcType: new FunType([FLOAT, FLOAT, FLOAT], FLOAT),
       ret: (args) => `${args[0]} * (1.0 - ${args[2]}) + ${args[1]} * ${args[2]}`,
     }, {
-      // TODO: bugs here
-      funcType: new FunType([FLOAT, FLOAT, FLOAT], FLOAT),
+      funcType: new FunType([FLOAT2, FLOAT2, FLOAT2], FLOAT2),
       ret: (args) => `rt.vec2.lerp(rt.vec2.create(), ${args[0]}, ${args[1]}, ${args[2]})`,
     }, {
       funcType: new FunType([FLOAT3, FLOAT3, FLOAT], FLOAT3),

--- a/src/backends/webglfunc.ts
+++ b/src/backends/webglfunc.ts
@@ -568,18 +568,15 @@ let funcMap: FuncMap = {
  * @return The compiled JavaScript function including arguments.
  */
 export function get_func(func: string, argTypes: Type[],
-                        args: string[], type?: Type): string | null
+                        args: string[]): string | null
 {
   if (funcMap[func]) {
     for (let paramsRet of funcMap[func]) {
-      let ret : Type | string | null = null;
-      if (type) {
-        ret = check_call(paramsRet.funcType, argTypes, type);
-      } else {
-        ret = check_call(paramsRet.funcType, argTypes);
-      }
+      let ret = check_call(paramsRet.funcType, argTypes);
       if (typeof(ret) !== "string") {
         return paramsRet.ret(args);
+      } else if (args.length == 0) {
+        paramsRet
       }
     }
     return null;

--- a/src/backends/webglfunc.ts
+++ b/src/backends/webglfunc.ts
@@ -488,6 +488,7 @@ let funcMap: FuncMap = {
       funcType: new FunType([FLOAT, FLOAT, FLOAT], FLOAT),
       ret: (args) => `${args[0]} * (1.0 - ${args[2]}) + ${args[1]} * ${args[2]}`,
     }, {
+      // TODO: bugs here
       funcType: new FunType([FLOAT, FLOAT, FLOAT], FLOAT),
       ret: (args) => `rt.vec2.lerp(rt.vec2.create(), ${args[0]}, ${args[1]}, ${args[2]})`,
     }, {
@@ -572,7 +573,7 @@ export function get_func(func: string, argTypes: Type[],
 {
   if (funcMap[func]) {
     for (let paramsRet of funcMap[func]) {
-      let ret : Type | string | null = null;
+      let ret: Type | string | null = null;
       if (type) {
         ret = check_call(paramsRet.funcType, argTypes, type);
       } else {

--- a/src/backends/webglfunc.ts
+++ b/src/backends/webglfunc.ts
@@ -540,6 +540,18 @@ let funcMap: FuncMap = {
       ),
       ret: (args) => `${args[0]}.push(${args[1]})`,
     },
+  ], "length": [
+    {
+      funcType: new QuantifiedType(TVAR,
+        new FunType(
+          [
+            new InstanceType(ARRAY, new VariableType(TVAR)),
+          ],
+          INT
+        )
+      ),
+      ret: (args) => `${args[0]}.length`,
+    },
   ],
 };
 

--- a/src/backends/webglfunc.ts
+++ b/src/backends/webglfunc.ts
@@ -568,11 +568,16 @@ let funcMap: FuncMap = {
  * @return The compiled JavaScript function including arguments.
  */
 export function get_func(func: string, argTypes: Type[],
-                        args: string[]): string | null
+                        args: string[], type?: Type): string | null
 {
   if (funcMap[func]) {
     for (let paramsRet of funcMap[func]) {
-      let ret = check_call(paramsRet.funcType, argTypes);
+      let ret : Type | string | null = null;
+      if (type) {
+        ret = check_call(paramsRet.funcType, argTypes, type);
+      } else {
+        ret = check_call(paramsRet.funcType, argTypes);
+      }
       if (typeof(ret) !== "string") {
         return paramsRet.ret(args);
       }

--- a/src/backends/webglfunc.ts
+++ b/src/backends/webglfunc.ts
@@ -4,7 +4,7 @@
  * and intrinsic functions in host-side code.
  */
 import { FLOAT4X4, FLOAT3X3, FLOAT4, FLOAT3, FLOAT2, ARRAY, TVAR, INTRINSICS } from './gl';
-import { Type, PrimitiveType, FLOAT, INT, VariableType, TypeVariable, InstanceType, QuantifiedType, VariadicFunType, OverloadedType, FunType, VOID } from '../type';
+import { Type, PrimitiveType, FLOAT, INT, VariableType, TypeVariable, InstanceType, QuantifiedType, VariadicFunType, OverloadedType, FunType, VOID, TypeKind } from '../type';
 import { check_call } from "../type_check";
 
 // The following two interfaces define the type of the function map below.
@@ -576,8 +576,10 @@ export function get_func(func: string, argTypes: Type[],
       let ret = check_call(paramsRet.funcType, argTypes);
       if (typeof(ret) !== "string") {
         return paramsRet.ret(args);
-      } else if (args.length == 0) {
-        paramsRet
+      } else if (args.length === 0
+        && paramsRet.funcType.kind === TypeKind.QUANTIFIED
+        && paramsRet.funcType.inner.kind === TypeKind.VARIADIC_FUN) {
+        return paramsRet.ret(args);
       }
     }
     return null;

--- a/src/backends/webglfunc.ts
+++ b/src/backends/webglfunc.ts
@@ -4,7 +4,7 @@
  * and intrinsic functions in host-side code.
  */
 import { FLOAT4X4, FLOAT3X3, FLOAT4, FLOAT3, FLOAT2, ARRAY, TVAR, INTRINSICS } from './gl';
-import { Type, PrimitiveType, FLOAT, INT, VariableType, TypeVariable, InstanceType, QuantifiedType, VariadicFunType, OverloadedType, FunType, VOID, TypeKind } from '../type';
+import { Type, PrimitiveType, FLOAT, INT, VariableType, TypeVariable, InstanceType, QuantifiedType, VariadicFunType, OverloadedType, FunType, VOID, TypeKind, STRING, BOOLEAN } from '../type';
 import { check_call } from "../type_check";
 
 // The following two interfaces define the type of the function map below.
@@ -551,6 +551,11 @@ let funcMap: FuncMap = {
         )
       ),
       ret: (args) => `${args[0]}.length`,
+    },
+  ], "equal": [
+    {
+      funcType: new FunType([STRING, STRING], BOOLEAN),
+      ret: (args) => `${args[0]} === ${args[1]}`,
     },
   ],
 };

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -240,11 +240,9 @@ TypeAlias
   = type _ i:ident _ eq _ t:Type
   { return loc({tag: "type_alias", ident:i, type:t}); }
 
-// Tuples are just pairs for now.
 Tuple
-  // = lhss:(e:MulBinary _ op:addbinop _)* rhs:MulBinary
   = e1:TermExpr e2:(_ comma _ TermExpr)+
-  { return buildList(e1, e2, "tuple"); }
+  { return loc({tag: "tuple", exprs: buildList(e1, e2, 3)}); }
 
 TupleIndex
   = t:TermExpr _ dot _ i:int
@@ -295,11 +293,9 @@ OverloadedTypeElement
   = _ pipe_operator _ t:NonOverloadedType
   { return t; }
 
-// As above, only 2-ary tuples.
 TupleType
-  = t1:TermType _ star _ t2:TermType
-  { return loc({tag: "type_tuple", components: [t1, t2]}); }
-
+  = t1:TermType t2:(_ star _ TermType)+
+  { return loc({tag: "type_tuple", components: buildList(t1, t2, 3)}); }
 
 // Tokens.
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -189,15 +189,17 @@ Arg
   { return e; }
 
 CCall
-  = i:Lookup paren_open _ as:CArgList? _ paren_close
-  { return loc({tag: "call", fun: i, args: as || []}); }
+  = i:Lookup type_param:TypeParam? paren_open _ as:CArgList? _ paren_close
+  { return loc({tag: "call", fun: i, args: as || [], type: type_param || undefined}); }
 CArgList
   = first:CArgument rest:CArgMore*
   { return [first].concat(rest); }
 CArgMore
   = _ comma _ e:CArgument
   { return e; }
-
+TypeParam
+  = brace_open _ t:NonOverloadedType _ brace_close
+  { return t; }
 MacroCall
   = macromark i:ident _ as:Arg+
   { return loc({tag: "macrocall", macro: i, args: as}); }
@@ -382,6 +384,12 @@ paren_open
 
 paren_close
   = ")"
+
+brace_open
+  = "{"
+
+brace_close
+  = "}"
 
 pipe_operator
   = "|"

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -23,7 +23,7 @@
     }
   }
 
-  function buildTuple(lhs, rhss) {
+  function buildList(lhs, rhss, tag) {
     if (rhss.length === 0) {
       return loc(lhs);
     } else {
@@ -31,7 +31,7 @@
       for (let rhs of rhss) {
         expr_list.push(loc(rhs[3]));
       }
-      return loc({tag: "tuple", exprs: expr_list});
+      return loc({tag: tag, exprs: expr_list});
     }
   }
 }
@@ -248,7 +248,7 @@ TypeAlias
 Tuple
   // = lhss:(e:MulBinary _ op:addbinop _)* rhs:MulBinary
   = e1:TermExpr e2:(_ comma _ TermExpr)+
-  { return buildTuple(e1, e2); }
+  { return buildList(e1, e2, "tuple"); }
 
 TupleIndex
   = t:TermExpr _ dot _ i:int

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -23,16 +23,12 @@
     }
   }
 
-  function buildList(lhs, rhss, tag) {
-    if (rhss.length === 0) {
-      return loc(lhs);
-    } else {
-      let expr_list = [loc(lhs)];
-      for (let rhs of rhss) {
-        expr_list.push(loc(rhs[3]));
-      }
-      return loc({tag: tag, exprs: expr_list});
+  function buildList(lhs, rhss, expr_index) {
+    let expr_list = [loc(lhs)];
+    for (let rhs of rhss) {
+      expr_list.push(loc(rhs[expr_index]));
     }
+    return expr_list;
   }
 }
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -22,6 +22,17 @@
       return loc({tag: "binary", lhs: lhs, rhs: rhs, op: last[2]});
     }
   }
+
+  function buildTuple(lhs, rhss) {
+    if (rhss.length === 0) {
+      return loc(lhs);
+    } else {
+      var first = rhss[0];
+      var rest = rhss.slice(1, rhss.length);
+      var rhs = buildTuple(first[3], rest);
+      return loc({tag: "tuple", exprs: [lhs, rhs]});
+    }
+  }
 }
 
 Program
@@ -232,8 +243,9 @@ TypeAlias
 
 // Tuples are just pairs for now.
 Tuple
-  = e1:TermExpr _ comma _ e2:TermExpr
-  { return loc({tag: "tuple", exprs: [e1, e2]}); }
+  // = lhss:(e:MulBinary _ op:addbinop _)* rhs:MulBinary
+  = e1:TermExpr e2:(_ comma _ TermExpr)+
+  { return buildTuple(e1, e2); }
 
 TupleIndex
   = t:TermExpr _ dot _ i:int

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -27,10 +27,11 @@
     if (rhss.length === 0) {
       return loc(lhs);
     } else {
-      var first = rhss[0];
-      var rest = rhss.slice(1, rhss.length);
-      var rhs = buildTuple(first[3], rest);
-      return loc({tag: "tuple", exprs: [lhs, rhs]});
+      let expr_list = [loc(lhs)];
+      for (let rhs of rhss) {
+        expr_list.push(loc(rhs[3]));
+      }
+      return loc({tag: "tuple", exprs: expr_list});
     }
   }
 }

--- a/src/interp.ts
+++ b/src/interp.ts
@@ -43,7 +43,7 @@ class Extern {
 }
 
 // Tuple values.
-interface Tuple { values: Value[] };
+interface Tuple { values: Value[]; }
 
 function unwrap_extern(v: Value): Value {
   if (v instanceof Extern) {

--- a/src/type_check.ts
+++ b/src/type_check.ts
@@ -734,10 +734,11 @@ function check_quantified(tvar: TypeVariable, target: Type,
           return param_error(i, param, arg);
         }
       } else {
-        if (vType === null || ret === vType) {
+        if (vType === null || compatible(ret, vType)) {
+          // TODO: we should find the most upper type of all arguments instead.
           vType = ret;
         } else {
-          return param_error(i, param, arg);
+          return param_error(i, vType, arg);
         }
       }
     }

--- a/src/type_check.ts
+++ b/src/type_check.ts
@@ -643,12 +643,12 @@ export function check_call(target: Type, args: Type[], type?: Type): Type | stri
 
       // The normal case for a polymorphic functions. Perform unification to
       // fill in the concrete type for the type variable.
-      let ret : Type | string | null = null;
+      let ret: Type | string | null = null;
       if (type) {
-        ret = check_quantified(target.variable, target.inner, args, type));
+        ret = check_quantified(target.variable, target.inner, args, type);
       }
       else {
-        ret = check_quantified(target.variable, target.inner, args));
+        ret = check_quantified(target.variable, target.inner, args);
       }
       if (typeof(ret) === "string") {
         return ret;
@@ -675,7 +675,7 @@ export function check_call(target: Type, args: Type[], type?: Type): Type | stri
  * Eventually, this should merge with `check_call` itself.
  */
 function check_quantified(tvar: TypeVariable, target: Type,
-                          args: Type[], annot_type?:Type): Type | string
+                          args: Type[], annot_type?: Type): Type | string
 {
   switch (target.kind) {
   // The inner function is a variadic function.
@@ -705,7 +705,7 @@ function check_quantified(tvar: TypeVariable, target: Type,
         }
       }
     }
-    if (args.length == 0 && annot_type) {
+    if (args.length === 0 && annot_type) {
       vType = annot_type;
     }
 


### PR DESCRIPTION
The syntax of generic function is array{Int}() where array is a function. It is pretty useful when we construct an empty array.
Multi-tuple is supported now. We can create a multiple elements tuple by `var t = (a, b, c)` and index it by `(t).2`.
Also, some bugs are fixed and useful built-in functions are added in this PR.